### PR TITLE
fix websocket bugs on query parameters get, and hijacked http connection

### DIFF
--- a/pkg/common/type.go
+++ b/pkg/common/type.go
@@ -15,9 +15,9 @@ type DownloadRequest struct {
 }
 
 type ExecuteRequest struct {
-	ID      uint64 `json:"id"`
-	Segment string `json:"segment"`
-	Start   int    `json:"start"`
-	End     int    `json:"end"`
-	Period  int    `json:"period"`
+	ID      uint64 `form:"id"`
+	Segment string `form:"segment"`
+	Start   int    `form:"start"`
+	End     int    `form:"end"`
+	Period  int    `form:"period"`
 }

--- a/service/websocket.go
+++ b/service/websocket.go
@@ -93,7 +93,7 @@ func (c *socketClient) readPump() {
 	for {
 		_, message, err := c.conn.ReadMessage()
 		if err != nil {
-			log.Printf("error: %v", err)
+			log.Printf("read error, but not really an error, this connection has been closed, so we can't read any more.: %v", err)
 			break
 		}
 		c.manager.receive <- map[*socketClient][]byte{
@@ -111,7 +111,7 @@ func (c *socketClient) writePump() {
 		if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil || !ok {
 			err = c.conn.WriteMessage(websocket.CloseMessage, []byte{})
 			if err != nil {
-				klog.Info("closed failed.")
+				klog.Info("we will close this connection.")
 			}
 			return
 		}


### PR DESCRIPTION
1. Webscocket query param bind shoud you keyword: form
2. we should not use upgraded connection with http server.
3. Some read error display.